### PR TITLE
fix: app card click area was larger than it have to be.

### DIFF
--- a/src/component/common/AppCard.tsx
+++ b/src/component/common/AppCard.tsx
@@ -1,9 +1,11 @@
 import { getApiImageUrl } from "../../network/constant/api-urls.ts";
+import { Link } from "react-router-dom";
 
 interface AppCardProps {
   title: string;
   description: string;
   image?: string;
+  to?: string;
 }
 
 /**
@@ -15,6 +17,7 @@ interface AppCardProps {
  * @param props.description The description of the card. Shown in 6 lines max.
  * @param props.image The image URL of the card. This is optional. The url will be processed by {@link getApiImageUrl}
  * function always.
+ * @param props.to The URL to navigate to when the card is clicked. This is optional.
  */
 function AppCard(props: AppCardProps) {
   return (
@@ -30,8 +33,8 @@ function AppCard(props: AppCardProps) {
   );
 }
 
-function AppCardFullSize({ title, image, description }: AppCardProps) {
-  return (
+function AppCardFullSize({ title, image, description, to }: AppCardProps) {
+  const content = (
     <div
       className={"flex bg-black rounded-2xl mb-8 w-full shadow shadow-black"}
     >
@@ -51,10 +54,16 @@ function AppCardFullSize({ title, image, description }: AppCardProps) {
       </div>
     </div>
   );
+
+  return (
+    <div className={"w-full"}>
+      {to ? <Link to={to}>{content}</Link> : content}
+    </div>
+  );
 }
 
-function AppCardCompact({ title, image, description }: AppCardProps) {
-  return (
+function AppCardCompact({ title, image, description, to }: AppCardProps) {
+  const content = (
     <div className={"bg-black rounded-2xl mb-8 pb-4 shadow shadow-black"}>
       {image && (
         <div className={"w-full h-64 rounded-t-2xl bg-gray-700"}>
@@ -73,6 +82,8 @@ function AppCardCompact({ title, image, description }: AppCardProps) {
       </div>
     </div>
   );
+
+  return to ? <Link to={to}>{content}</Link> : content;
 }
 
 export default AppCard;

--- a/src/component/home/ContactIntroducerCard.tsx
+++ b/src/component/home/ContactIntroducerCard.tsx
@@ -1,5 +1,4 @@
 import AppCard from "../common/AppCard.tsx";
-import { Link } from "react-router-dom";
 import { HomePageContactIntroducerData } from "../../data/api-data-types";
 
 interface ContactIntroducerCardProps {
@@ -8,9 +7,11 @@ interface ContactIntroducerCardProps {
 
 function ContactIntroducerCard({ data }: ContactIntroducerCardProps) {
   return (
-    <Link to={"/contact"}>
-      <AppCard title={data.title} description={data.description} />
-    </Link>
+    <AppCard
+      title={data.title}
+      description={data.description}
+      to={"/contact"}
+    />
   );
 }
 

--- a/src/component/home/PortfolioIntroducerCard.tsx
+++ b/src/component/home/PortfolioIntroducerCard.tsx
@@ -1,5 +1,4 @@
 import AppCard from "../common/AppCard.tsx";
-import { Link } from "react-router-dom";
 import { HomePagePortfolioIntroducerData } from "../../data/api-data-types";
 
 interface PortfolioIntroducerCardProps {
@@ -7,11 +6,7 @@ interface PortfolioIntroducerCardProps {
 }
 
 function PortfolioIntroducerCard({ data }: PortfolioIntroducerCardProps) {
-  return (
-    <Link to={"/portfolio"}>
-      <AppCard {...data} />
-    </Link>
-  );
+  return <AppCard {...data} to={"/portfolio"} />;
 }
 
 export default PortfolioIntroducerCard;

--- a/src/component/portfolio/PortfolioEntry.tsx
+++ b/src/component/portfolio/PortfolioEntry.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import AppCard from "../common/AppCard.tsx";
 import { PortfolioPreviewData } from "../../data/api-data-types";
 
@@ -8,13 +7,12 @@ interface PortfolioEntryProps {
 
 function PortfolioEntry({ data }: PortfolioEntryProps) {
   return (
-    <Link to={`/portfolio/${data.slug}`}>
-      <AppCard
-        title={data.title}
-        description={data.description}
-        image={data.image}
-      />
-    </Link>
+    <AppCard
+      title={data.title}
+      description={data.description}
+      image={data.image}
+      to={`/portfolio/${data.slug}`}
+    />
   );
 }
 


### PR DESCRIPTION
* AppCard has `to` prop for routing the given page.
* All Link wraps are removed over AppCard in scope of the project.